### PR TITLE
Remove future incompatiblity (trailing ; in macro body)

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -471,8 +471,8 @@ macro_rules! dsz_unwrap {
             Err(err) => {
                 return Err(err.into());
             }
-        };
-    };
+        }
+    }
 }
 
 impl<R> CraftReader<R> {


### PR DESCRIPTION
Fixes a warning on nightly: https://github.com/rust-lang/rust/issues/79813